### PR TITLE
CPIT-631 Small bugs and improvements

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -212,11 +212,16 @@ import { CMDefaultValue } from './carbon-market/entity/cm-default-value.entity';
     MailerModule.forRoot({
       transport: {
         host: process.env.EMAIL_HOST,
+        name: 'unops.org',
+        pool: true,
         port: 587,
         secure: false,
+        tls: {
+          rejectUnauthorized: false,
+        },
       },
       defaults: {
-        from: '"Admin"' + process.env.EMAIL,
+        from: '"Admin" <' + process.env.EMAIL + '>',
       },
     }),
     ParameterRequestModule,

--- a/src/carbon-market/service/assessment-cm-detail.service.ts
+++ b/src/carbon-market/service/assessment-cm-detail.service.ts
@@ -142,6 +142,19 @@ export class AssessmentCMDetailService extends TypeOrmCrudService<AssessmentCMDe
     }
   }
 
+  async updateExpectedGhgMitigation(cmDetailId: number, expectedGhgMitigation: number) {
+    try {
+      await this.repo
+        .createQueryBuilder()
+        .update(AssessmentCMDetail)
+        .set({ expected_ghg_mitigation: expectedGhgMitigation })
+        .where("id = :id", { id: cmDetailId })
+        .execute();
+    } catch (error) {
+      throw new InternalServerErrorException(error)
+    }
+  }
+
   async deleteCmAssessmentDetail(assessmentId: number) {
     await this.deleteGeographicalAreasCovered(assessmentId);
     await this.deleteInvestorSector(assessmentId);

--- a/src/carbon-market/service/cm-assessment-question.service.ts
+++ b/src/carbon-market/service/cm-assessment-question.service.ts
@@ -195,14 +195,10 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
 
         this.saveTcValue(assessment.id, res);
       }
-      if (expectedGHGMitigation || expectedGHGMitigation === null || expectedGHGMitigation === 0) {
+      if (expectedGHGMitigation !== undefined) {
         let cm_detail = await this.assessmentCMDetailService.getAssessmentCMDetailByAssessmentId(assessment.id)
         if (cm_detail) {
-          cm_detail.expected_ghg_mitigation = expectedGHGMitigation;
-          cm_detail.cmassessment = undefined
-          cm_detail.geographicalAreasCovered = undefined
-          cm_detail.sectorsCovered = undefined
-          this.assessmentCMDetailService.save(cm_detail)
+          await this.assessmentCMDetailService.updateExpectedGhgMitigation(cm_detail.id, expectedGHGMitigation);
         }
       }
       return a_ans
@@ -290,7 +286,6 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
 
   async calculateProcessResult(questions: CMAssessmentQuestion[]) {
 
-
     let categories = [...new Set(questions.map(q => q.characteristic.category.code))]
     let obj = {}
 
@@ -301,6 +296,7 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
         let _obj: CharacteristicData = new CharacteristicData()
         _obj.characteristic = chs[ch][0].characteristic.code
         _obj.relevance = chs[ch][0].relevance
+        _obj.ch_weight = chs[ch][0].characteristic.cm_weight
         let weight = chs[ch][0].characteristic.cm_weight
         let score = null
         chs[ch].forEach(_ch => {
@@ -308,7 +304,8 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
             score += _ch.assessmentAnswers[0].score
           }
         })
-        _obj.score = _obj.relevance === '0' ? null : (_obj.relevance === '1' ? Math.round(score * weight / 2 / 100) : Math.round(score * weight / 100))
+        let isNotRelevant = +_obj.relevance === 0
+        _obj.score = isNotRelevant ? null : (+_obj.relevance === 1 ? Math.round(score * weight / 2 / 100) : Math.round(score * weight / 100))
         return _obj
       })
       let cat_data = { characteristics: ch_data, weight: qs[0].characteristic.category.cm_weight }
@@ -317,19 +314,30 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
 
     let resObj = {}
     for (let key of Object.keys(obj)) {
+      let relevantChars = obj[key].characteristics.filter(ch => +ch.relevance !== 0 && ch.score !== null)
+      let totalRelevantWeight = relevantChars.reduce((sum, ch) => sum + ch.ch_weight, 0)
+
       let score = null
-      obj[key].characteristics.forEach(ch => {
-        if (ch.relevance !== 0) {
-          score += ch.score
-        }
-      })
+      if (relevantChars.length > 0 && totalRelevantWeight > 0) {
+        score = 0
+        relevantChars.forEach(ch => {
+          let normalizedWeight = ch.ch_weight / totalRelevantWeight
+          score += ch.score * normalizedWeight
+        })
+        score = Math.round(score)
+      }
       resObj[key] = { score: score, weight: obj[key].weight }
     }
 
+    let relevantCategories = Object.keys(resObj).filter(key => resObj[key].score !== null)
+    let totalRelevantCatWeight = relevantCategories.reduce((sum, key) => sum + resObj[key].weight, 0)
+
     let process_score = null
-    for (let key of Object.keys(resObj)) {
-      process_score === null ? (resObj[key].score === null ? process_score === null : process_score = Math.round(resObj[key].score * resObj[key].weight / 100)) :
-        process_score += Math.round(resObj[key].score * resObj[key].weight / 100)
+    if (relevantCategories.length > 0 && totalRelevantCatWeight > 0) {
+      process_score = 0
+      for (let key of relevantCategories) {
+        process_score += Math.round(resObj[key].score * resObj[key].weight / totalRelevantCatWeight)
+      }
     }
 
     return process_score
@@ -394,23 +402,40 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
     let scale_ghg_score = null; let scale_sdg_score = null; let scale_adaptation_score = null;
     let sustained_ghg_score = null; let sustained_sdg_score = null; let sustained_adaptation_score = null;
     let outcome_score = null
+
+    let outcomeComponents: { score: number, weight: number }[] = []
+
     if (obj['SCALE_GHG']) {
       scale_ghg_score = obj['SCALE_GHG'].score
       sustained_ghg_score = obj['SUSTAINED_GHG']?.score
       ghg_score = scale_ghg_score === null && sustained_ghg_score === null ? null : (scale_ghg_score + sustained_ghg_score) / 2;
-      ghg_score  !== null ? outcome_score += (ghg_score * obj['SCALE_GHG'].weight / 100) : outcome_score = outcome_score
+      if (ghg_score !== null) {
+        outcomeComponents.push({ score: ghg_score, weight: obj['SCALE_GHG'].weight })
+      }
     }
     if (obj['SCALE_SD']) {
       scale_sdg_score = obj['SCALE_SD'].score
       sustained_sdg_score = obj['SUSTAINED_SD']?.score
       sdg_score = scale_sdg_score === null && sustained_sdg_score === null ? null : (scale_sdg_score + sustained_sdg_score) / 2;
-      sdg_score !== null ? outcome_score += (sdg_score * obj['SCALE_SD'].weight / 100) : outcome_score = outcome_score
+      if (sdg_score !== null) {
+        outcomeComponents.push({ score: sdg_score, weight: obj['SCALE_SD'].weight })
+      }
     }
     if (obj['SCALE_ADAPTATION']) {
       scale_adaptation_score = obj['SCALE_ADAPTATION'].score
       sustained_adaptation_score = obj['SUSTAINED_ADAPTATION'].score
       adaptation_score = scale_adaptation_score === null && sustained_adaptation_score === null ? null : (scale_adaptation_score + sustained_adaptation_score) / 2;
-      adaptation_score !== null ? outcome_score += (adaptation_score * obj['SCALE_ADAPTATION']?.weight / 100) : outcome_score = outcome_score
+      if (adaptation_score !== null) {
+        outcomeComponents.push({ score: adaptation_score, weight: obj['SCALE_ADAPTATION']?.weight })
+      }
+    }
+
+    if (outcomeComponents.length > 0) {
+      let totalRelevantWeight = outcomeComponents.reduce((sum, c) => sum + c.weight, 0)
+      outcome_score = 0
+      for (let comp of outcomeComponents) {
+        outcome_score += comp.score * comp.weight / totalRelevantWeight
+      }
     }
 
     return {
@@ -528,12 +553,15 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
       let criteria = []
       let sdgs = []
 
-      let added_chs: number[] = []
+      let added_chs: string[] = []
       let uniqueAnswers = []
       for (let answ of answers) {
-        if (!added_chs.includes(answ.assessment_question?.characteristic?.id) && answ.assessment_question.comment !== null && answ.assessment_question.comment !== undefined) {
+        let chId = answ.assessment_question?.characteristic?.id
+        let sdgId = answ.assessment_question?.selectedSdg?.id
+        let compositeKey = `${chId}_${sdgId ?? 'none'}`
+        if (!added_chs.includes(compositeKey) && answ.assessment_question.comment !== null && answ.assessment_question.comment !== undefined) {
           uniqueAnswers.push(answ);
-          added_chs.push(answ.assessment_question?.characteristic?.id)
+          added_chs.push(compositeKey)
         }
       }
 
@@ -773,11 +801,13 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
 
       if (isAllchNull) {cat_score = null;}
       else {
-        ch_data.map(ch => {
-          if (ch.ch_score !== null) {
-            cat_score += (ch.ch_score * ch.weight / 100);
-          }
-        })
+        let relevantChs = ch_data.filter(ch => ch.ch_score !== null)
+        let totalRelevantWeight = relevantChs.reduce((sum, ch) => sum + ch.weight, 0)
+        if (totalRelevantWeight > 0) {
+          relevantChs.map(ch => {
+            cat_score += (ch.ch_score * ch.weight / totalRelevantWeight);
+          })
+        }
       }
 
       cat_score = cat_score === null ? null : Math.round(cat_score)

--- a/src/carbon-market/service/cm-assessment-question.service.ts
+++ b/src/carbon-market/service/cm-assessment-question.service.ts
@@ -97,14 +97,21 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
         }
       }
       if (isDraft) {
-        assessment.isDraft = isDraft;
-        assessment.lastDraftLocation = type;
+        const draftFields: any = {
+          isDraft,
+          lastDraftLocation: type,
+        };
         if (type == "prose") {
-          assessment.processDraftLocation = name;
+          draftFields.processDraftLocation = name;
         } else if (type == "out") {
-          assessment.outcomeDraftLocation = name;
+          draftFields.outcomeDraftLocation = name;
         }
-        this.assessmentRepo.save(assessment)
+        await this.assessmentRepo
+          .createQueryBuilder()
+          .update(Assessment)
+          .set(draftFields)
+          .where("id = :id", { id: assessment.id })
+          .execute();
       }
       for await (let res of results) {
         let ass_question = new CMAssessmentQuestion()

--- a/src/climate-action/climate-action.controller.ts
+++ b/src/climate-action/climate-action.controller.ts
@@ -348,14 +348,14 @@ export class ProjectController implements CrudController<ClimateAction> {
   async delete(
     @Query('id') id: number,
   ): Promise<any> {
-    this.service.delete(id);
+    await this.service.delete(id);
   }
 
   @Post('delete-p-sector')
   async deletePolicySector(
     @Query('id') id: number,
   ): Promise<any> {
-    this.service.deletePolicySector(id);
+    await this.service.deletePolicySector(id);
   }
 
     @Post('add-p-sector')

--- a/src/climate-action/climate-action.service.ts
+++ b/src/climate-action/climate-action.service.ts
@@ -489,7 +489,7 @@ export class ProjectService extends TypeOrmCrudService<ClimateAction> {
       policy.id =obj.id;
       ps.sector =sec;
       ps.intervention= policy;
-      this.PolicySectorsRepo.save(ps)
+      await this.PolicySectorsRepo.save(ps);
     }
   }
 

--- a/src/investor-tool/investor-tool.service.ts
+++ b/src/investor-tool/investor-tool.service.ts
@@ -1567,9 +1567,18 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool>{
         aggre_Score += category.category_score.value
         sdg_count_aggre++;
     }
+
+    let totalRelevantOutcomeWeight = 0;
+    for (let category of outcomeArray) {
+      if (!category.isSDG && category.category_score?.value !== null && category.category_score?.value !== undefined) {
+        totalRelevantOutcomeWeight += category.category_weight;
+      }
+    }
+
     if(sdg_count_aggre!=0){
       finalProcessDataArray.aggregatedScore.value = this.roundDown(aggre_Score/2);
       finalProcessDataArray.aggregatedScore.name = this.mapScaleScores(this.roundDown(aggre_Score/sdg_count_aggre));
+      totalRelevantOutcomeWeight += 50;
       total_outcome_cat_weight += 50*(finalProcessDataArray.aggregatedScore.value);
     }
     else{
@@ -1578,9 +1587,9 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool>{
     }
     
     finalProcessDataArray.outcomeData = outcomeArray;
-    if (total_outcome_cat_weight != null){
+    if (total_outcome_cat_weight != null && totalRelevantOutcomeWeight > 0){
       
-      finalProcessDataArray.outcomeScore = this.roundDown(total_outcome_cat_weight / 100);
+      finalProcessDataArray.outcomeScore = this.roundDown(total_outcome_cat_weight / totalRelevantOutcomeWeight);
       
     }
     let scale_sdg= finalProcessDataArray?.outcomeData?.find((item: { code: string; })=>item?.code=='SCALE_SD');

--- a/src/investor-tool/investor-tool.service.ts
+++ b/src/investor-tool/investor-tool.service.ts
@@ -973,6 +973,7 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool>{
       .addSelect('sector.id')
       .addSelect('COUNT(investorSector.id)', 'count')
       .groupBy('sector.name')
+      .addGroupBy('sector.id')
       .having('sector IS NOT NULL')
       .getRawMany();
 
@@ -1028,6 +1029,7 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool>{
       .addSelect('sector.id')
       .addSelect('COUNT(investorSector.id)', 'count')
       .groupBy('sector.name')
+      .addGroupBy('sector.id')
       .having('sector IS NOT NULL')
       .getRawMany();
 
@@ -1766,6 +1768,7 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool>{
       .addSelect('sdg.number', 'number')
       .addSelect('count(DISTINCT concat(assessment.id, sdg.id))', 'count')
       .groupBy('sdg.name')
+      .addGroupBy('sdg.number')
       .having('sdg IS NOT NULL')
       ;
     return await sectorSum.getRawMany();

--- a/src/report/report.controller.ts
+++ b/src/report/report.controller.ts
@@ -170,57 +170,64 @@ export class ReportController {
     @Body() req: CreateComparisonReportDto,
     @Res({ passthrough: true }) res, 
   ): Promise<any> {
-   
-    let countryIdFromTocken: number;
-    let UsernnameFromTocken: string;
-    [countryIdFromTocken,UsernnameFromTocken] =
-      this.tokenDetails.getDetails([
-        TokenReqestType.countryId,TokenReqestType.username
-      ]);
-    req.reportTitle = req.reportTitle
-
-    const randomName = Array(8)
-    .fill(null)
-    .map(() => Math.round(Math.random() * 16).toString(16))
-    .join('');
-    const uniqname = req.reportName+randomName + '.pdf';
-    req.reportName = req.reportName + '.pdf';
-   
-    const reprtDto: ComparisonReportDto = await this.reportService.genarateComparisonReportDto(
-      req,
-    );
- 
-   const reportpdf:Buffer= await this.reportGenarateService.comparisonReportGenarate(
-    uniqname,
-      await this.reportHtmlGenarateService.comparisonReportHtmlGenarate(reprtDto),
-    )
-
-    const filePath = `./public/${uniqname}`;
-      
-       
-    try {
-   
-  
- 
-      await this.storageService.save(
-        'reports/' + uniqname,
-        'application/pdf',
-        reportpdf,
-        [{ mediaId: uniqname }]
-      );
-     
-    } catch (e) {
-      if (e.message.toString().includes("No such object")) {
-        throw new NotFoundException("file not found");
-      } else {
-        throw new ServiceUnavailableException("internal error");
-      }
+    let details = await this.auditDetailService.getAuditDetails()
+    let obj = {
+      description: "Generate comparison report"
     }
- 
-    let report=  await this.reportService.saveReport(req.reportName,uniqname, UsernnameFromTocken, req.climateAction,req.portfolioId,req.tool,req.type);
+    let body = { ...details, ...obj }
+    try {
+      let countryIdFromTocken: number;
+      let UsernnameFromTocken: string;
+      [countryIdFromTocken,UsernnameFromTocken] =
+        this.tokenDetails.getDetails([
+          TokenReqestType.countryId,TokenReqestType.username
+        ]);
+      req.reportTitle = req.reportTitle
 
-     fsPromises.rm(filePath);
-    return report;
+      const randomName = Array(8)
+      .fill(null)
+      .map(() => Math.round(Math.random() * 16).toString(16))
+      .join('');
+      const uniqname = req.reportName+randomName + '.pdf';
+      req.reportName = req.reportName + '.pdf';
+    
+      const reprtDto: ComparisonReportDto = await this.reportService.genarateComparisonReportDto(
+        req,
+      );
+
+      const reportpdf:Buffer= await this.reportGenarateService.comparisonReportGenarate(
+        uniqname,
+        await this.reportHtmlGenarateService.comparisonReportHtmlGenarate(reprtDto),
+      )
+
+      const filePath = `./public/${uniqname}`;
+
+      try {
+        await this.storageService.save(
+          'reports/' + uniqname,
+          'application/pdf',
+          reportpdf,
+          [{ mediaId: uniqname }]
+        );
+      } catch (e) {
+        if (e.message.toString().includes("No such object")) {
+          throw new NotFoundException("file not found");
+        } else {
+          throw new ServiceUnavailableException("internal error");
+        }
+      }
+
+      let report = await this.reportService.saveReport(req.reportName,uniqname, UsernnameFromTocken, req.climateAction,req.portfolioId,req.tool,req.type);
+
+      body = { ...body, ...{ actionStatus: "Comparison report generated successfully", } }
+      this.auditDetailService.log(body)
+      fsPromises.rm(filePath);
+      return report;
+    } catch (error) {
+      body = { ...body, ...{ actionStatus: "Failed to generate comparison report", } }
+      this.auditDetailService.log(body)
+      throw new InternalServerErrorException(error)
+    }
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import * as moment from 'moment';
 import { CreateComparisonReportDto, CreateReportDto } from './dto/create-report.dto';
 import { UpdateReportDto } from './dto/update-report.dto';
 import { AssessmentDto } from './dto/assessment.dto';
@@ -78,8 +79,12 @@ export class ReportService extends TypeOrmCrudService<Report> {
     return `This action updates a #${id} report`;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} report`;
+  async remove(id: number) {
+    const report = await this.repo.findOne({ where: { id } });
+    if (!report) return { message: `Report #${id} not found` };
+    report.status = -20;
+    await this.repo.save(report);
+    return { message: `Report #${id} deleted successfully` };
   }
   async findReportByID(id: number):Promise<Report> {
     
@@ -249,6 +254,7 @@ export class ReportService extends TypeOrmCrudService<Report> {
   
     }
 
+    res = res.filter(r => r.status !== -20);
     let reportList: Report[] = [];
     const isUserExternal = currentUser?.userType?.name === 'External';
     for await  (const x of await res) {
@@ -317,15 +323,13 @@ export class ReportService extends TypeOrmCrudService<Report> {
       {
         information: 'Date of implementation',
         description: asse.climateAction.dateOfImplementation
-          ? new Date(
-            asse.climateAction.dateOfImplementation,
-          ).toLocaleDateString()
+          ? moment(asse.climateAction.dateOfImplementation).format('DD/MM/YYYY')
           : 'N/A',
       },
       {
         information: 'Date of completion (if relevant)',
         description: asse.climateAction.dateOfCompletion
-          ? new Date(asse.climateAction.dateOfCompletion).toLocaleDateString()
+          ? moment(asse.climateAction.dateOfCompletion).format('DD/MM/YYYY')
           : 'N/A',
       },
       {
@@ -1566,15 +1570,13 @@ export class ReportService extends TypeOrmCrudService<Report> {
       {
         information: 'Date of implementation',
         description: asse.climateAction.dateOfImplementation
-          ? new Date(
-            asse.climateAction.dateOfImplementation,
-          ).toLocaleDateString()
+          ? moment(asse.climateAction.dateOfImplementation).format('DD/MM/YYYY')
           : 'N/A',
       },
       {
         information: 'Date of completion (if relevant)',
         description: asse.climateAction.dateOfCompletion
-          ? new Date(asse.climateAction.dateOfCompletion).toLocaleDateString()
+          ? moment(asse.climateAction.dateOfCompletion).format('DD/MM/YYYY')
           : 'N/A',
       },
       {

--- a/src/utills/token_details.ts
+++ b/src/utills/token_details.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 
 @Injectable()
@@ -10,6 +10,9 @@ export class TokenDetails {
 
     getDetails(reqDetails: TokenReqestType[]): any[] {
         let details: any[] = [];
+        if (!this.request?.user?.user) {
+            throw new UnauthorizedException('Invalid or expired token');
+        }
         let user: any = this.request.user.user;
         for (let det of reqDetails) {
             switch (det) {


### PR DESCRIPTION
TC toolkit bugs across backend and frontend
- Fix SDG GROUP BY error in sdgSumCalculate (investor-tool.service)
- Add null guard to TokenDetails to prevent 500 on expired JWT
- Fix multi-user data loss: add await to policy sector save, remove setTimeout race condition
- Fix draft save overwriting assessment dates (use targeted UPDATE)
- Add Save as Draft to Carbon Market initial assessment form
- Auto-populate from_date from intervention dateOfImplementation
- Increase file upload limit from 5MB to 25MB
- Implement report soft-delete with frontend delete button
- Add error handling/audit logging to generateComparisonReport
- Fix goToAllTool missing parentheses in dashboard
- Standardize report PDF dates to DD/MM/YYYY via moment