### PR TITLE
[CPIT-650][CPIT-649]

### DIFF
--- a/src/carbon-market/service/cm-assessment-question.service.ts
+++ b/src/carbon-market/service/cm-assessment-question.service.ts
@@ -33,6 +33,10 @@ import {
   shouldFallbackGhgScaleToSdg13,
   shouldFallbackGhgSustainedToSdg13,
 } from 'src/shared/outcome-ghg-fallback.util';
+import {
+  floorToHalf,
+  floorToHalfOrNull,
+} from 'src/shared/score-rounding.util';
 
 @Injectable()
 export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessmentQuestion> {
@@ -408,7 +412,7 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
           code: first.characteristic.code,
           relevance: first.relevance,
           weight: first.characteristic.cm_weight,
-          ch_score: score === null ? null : Math.round(score),
+          ch_score: score,
         });
       });
 
@@ -450,7 +454,7 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
           : sum,
       0,
     );
-    return Math.round(process_score);
+    return floorToHalfOrNull(process_score);
   }
 
   async calculateOutcomeResult(
@@ -533,7 +537,7 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
       sdgs_score[key] =
         sdgs_score[key] === null
           ? null
-          : Math.round(sdgs_score[key] / valid_sdg_score_count[key]);
+          : floorToHalf(sdgs_score[key] / valid_sdg_score_count[key]);
     }
 
     let ghg_score = null;
@@ -653,27 +657,16 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
     }
 
     return {
-      ghg_score: ghg_score === null ? null : Math.round(ghg_score),
-      sdg_score: sdg_score === null ? null : Math.round(sdg_score),
-      adaptation_score:
-        adaptation_score === null ? null : Math.round(adaptation_score),
-      outcome_score: outcome_score === null ? null : Math.round(outcome_score),
-      scale_ghg_score:
-        scale_ghg_score === null ? null : Math.round(scale_ghg_score),
-      sustained_ghg_score:
-        sustained_ghg_score === null ? null : Math.round(sustained_ghg_score),
-      scale_sdg_score:
-        scale_sdg_score === null ? null : Math.round(scale_sdg_score),
-      sustained_sdg_score:
-        sustained_sdg_score === null ? null : Math.round(sustained_sdg_score),
-      scale_adaptation_score:
-        scale_adaptation_score === null
-          ? null
-          : Math.round(scale_adaptation_score),
-      sustained_adaptation_score:
-        sustained_adaptation_score === null
-          ? null
-          : Math.round(sustained_adaptation_score),
+      ghg_score: floorToHalfOrNull(ghg_score),
+      sdg_score: floorToHalfOrNull(sdg_score),
+      adaptation_score: floorToHalfOrNull(adaptation_score),
+      outcome_score: floorToHalfOrNull(outcome_score),
+      scale_ghg_score: floorToHalfOrNull(scale_ghg_score),
+      sustained_ghg_score: floorToHalfOrNull(sustained_ghg_score),
+      scale_sdg_score: floorToHalfOrNull(scale_sdg_score),
+      sustained_sdg_score: floorToHalfOrNull(sustained_sdg_score),
+      scale_adaptation_score: floorToHalfOrNull(scale_adaptation_score),
+      sustained_adaptation_score: floorToHalfOrNull(sustained_adaptation_score),
       sdgs_score: sdgs_score,
     };
   }
@@ -1118,6 +1111,8 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
           }, 0);
         }
 
+        const rawChScore = score;
+
         return Object.assign(new CharacteristicProcessData(), {
           name: first.characteristic.name,
           code: first.characteristic.code,
@@ -1125,11 +1120,12 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
           weight: first.characteristic.cm_weight,
           questions,
           raw_questions: [...questions],
-          ch_score: score === null ? null : Math.round(score),
+          ch_score: rawChScore === null ? null : floorToHalf(rawChScore),
+          rawChScore,
         });
       });
 
-      const relevantChs = ch_data.filter((ch) => ch.ch_score !== null);
+      const relevantChs = ch_data.filter((ch) => ch.rawChScore !== null);
       const effectiveWeight = (ch: CharacteristicProcessData) =>
         +ch.relevance === 1 ? ch.weight / 2 : ch.weight;
 
@@ -1142,10 +1138,11 @@ export class CMAssessmentQuestionService extends TypeOrmCrudService<CMAssessment
       if (relevantChs.length > 0 && totalRelevantWeight > 0) {
         const temp_score = relevantChs.reduce(
           (sum, ch) =>
-            sum + (ch.ch_score * effectiveWeight(ch)) / totalRelevantWeight,
+            sum +
+            (ch.rawChScore * effectiveWeight(ch)) / totalRelevantWeight,
           0,
         );
-        cat_score = Math.round(temp_score);
+        cat_score = floorToHalf(temp_score);
       }
 
       data.push({
@@ -1616,6 +1613,7 @@ export class CharacteristicProcessData {
   weight: number;
   score: number;
   ch_score: number;
+  rawChScore?: number | null;
   questions: QuestionData[];
   raw_questions: QuestionData[];
 }

--- a/src/investor-tool/investor-tool.service.ts
+++ b/src/investor-tool/investor-tool.service.ts
@@ -30,6 +30,10 @@ import {
   shouldFallbackGhgScaleToSdg13,
   shouldFallbackGhgSustainedToSdg13,
 } from 'src/shared/outcome-ghg-fallback.util';
+import {
+  floorToHalf,
+  floorToHalfOrNull,
+} from 'src/shared/score-rounding.util';
 import { UsersService } from 'src/users/users.service';
 import { MethodologyAssessmentService } from 'src/methodology-assessment/methodology-assessment.service';
 import { User } from 'src/users/entity/user.entity';
@@ -1314,10 +1318,10 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
       });
       finalDataArray.push({
         assessment: obj,
-        likelihood: Math.round(finalLikelihood / 4),
-        relevance: Math.round(finalrelevance / 4),
-        scaleScore: Math.round(scaleScoreTotal / 2),
-        sustainedScore: Math.round(sustainedScoreTotal / 2),
+        likelihood: floorToHalf(finalLikelihood / 4),
+        relevance: floorToHalf(finalrelevance / 4),
+        scaleScore: floorToHalf(scaleScoreTotal / 2),
+        sustainedScore: floorToHalf(sustainedScoreTotal / 2),
       });
     }
 
@@ -1487,9 +1491,8 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
               Math.round(char.recalculated_char_weight / 10) * 10;
           }
           if (!isNaN(char.likelihood.value)) {
-            cat_score += this.round(
-              char.recalculated_char_weight * char.likelihood.value,
-            );
+            cat_score +=
+              char.recalculated_char_weight * char.likelihood.value;
           }
         } else {
           char.recalculated_char_weight = 0;
@@ -1501,10 +1504,15 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
         )
       ) {
         category.category_score = { name: '-', value: null };
+        (category as { rawCategoryScore?: number | null }).rawCategoryScore =
+          null;
       } else {
+        const rawCategoryScore = cat_score / 100;
+        (category as { rawCategoryScore?: number | null }).rawCategoryScore =
+          rawCategoryScore;
         category.category_score = {
-          name: this.mapLikelihood(this.round(cat_score / 100)),
-          value: this.round(cat_score / 100),
+          name: this.mapLikelihood(floorToHalf(rawCategoryScore)),
+          value: floorToHalf(rawCategoryScore),
         };
         total_cat_weight += category.category_weight;
       }
@@ -1516,18 +1524,21 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
         item.recalculated_category_weight = Math.round(
           (item.category_weight / total_cat_weight) * 100,
         );
+        const rawCategoryScore =
+          (item as { rawCategoryScore?: number | null }).rawCategoryScore ?? 0;
         process_score === null
           ? item.category_score.value === null
             ? null
             : (process_score =
-                item.recalculated_category_weight * item.category_score.value)
+                item.recalculated_category_weight * rawCategoryScore)
           : (process_score +=
-              item.recalculated_category_weight * item.category_score.value);
+              item.recalculated_category_weight * rawCategoryScore);
       }
     });
     finalProcessDataArray.processData = categoryDataArray;
-    finalProcessDataArray.processScore =
-      process_score === null ? null : this.round(process_score / 100);
+    finalProcessDataArray.processScore = floorToHalfOrNull(
+      process_score === null ? null : process_score / 100,
+    );
 
     let total_outcome_cat_weight = null;
     let outcomeArray: (typeof outcomeCategoryData)[] = [];
@@ -1611,16 +1622,22 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
           }
           if (char.data.every((element) => element.isCalulate === false)) {
             char.sdg_score = null;
+            char.rawSdgScore = null;
           } else {
-            char.sdg_score = this.round(sdg_cat_score / sdg_total_char);
+            const rawSdgScore = sdg_cat_score / sdg_total_char;
+            char.rawSdgScore = rawSdgScore;
+            char.sdg_score = floorToHalf(rawSdgScore);
             sdg_count++;
-            total_sdg_score += char.sdg_score;
+            total_sdg_score += rawSdgScore;
           }
         }
         if (sdg_count != 0) {
+          const rawCategoryScore = total_sdg_score / sdg_count;
+          (category as { rawCategoryScore?: number | null }).rawCategoryScore =
+            rawCategoryScore;
           category.category_score = {
-            name: this.mapScaleScores(this.round(total_sdg_score / sdg_count)),
-            value: this.round(total_sdg_score / sdg_count),
+            name: this.mapScaleScores(floorToHalf(rawCategoryScore)),
+            value: floorToHalf(rawCategoryScore),
           };
           sdgArray.push(category);
         }
@@ -1639,13 +1656,18 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
           )
         ) {
           category.category_score = { name: '-', value: null };
+          (category as { rawCategoryScore?: number | null }).rawCategoryScore =
+            null;
         } else {
+          const rawCategoryScore = cat_score / total_char;
+          (category as { rawCategoryScore?: number | null }).rawCategoryScore =
+            rawCategoryScore;
           category.category_score = {
-            name: this.mapScaleScores(this.round(cat_score / total_char)),
-            value: this.round(cat_score / total_char),
+            name: this.mapScaleScores(floorToHalf(rawCategoryScore)),
+            value: floorToHalf(rawCategoryScore),
           };
           total_outcome_cat_weight +=
-            category.category_weight * category.category_score.value;
+            category.category_weight * rawCategoryScore;
         }
       }
     }
@@ -1666,28 +1688,35 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
       const sdg13Entry = sdgCategory.characteristicData.find((char) =>
         char.name?.startsWith(SDG_CLIMATE_ACTION_SCALE_NAME_PREFIX),
       );
+      const rawSdg13Score =
+        sdg13Entry?.rawSdgScore ?? sdg13Entry?.sdg_score ?? null;
 
       if (
         !shouldFallback(
           ghgScores,
-          ghgCategory.category_score?.value,
-          sdg13Entry?.sdg_score ?? null,
+          (ghgCategory as { rawCategoryScore?: number | null })
+            .rawCategoryScore ?? ghgCategory.category_score?.value,
+          rawSdg13Score,
         )
       ) {
         return;
       }
 
-      const previousGhgScore = ghgCategory.category_score?.value ?? 0;
+      const previousGhgScore =
+        (ghgCategory as { rawCategoryScore?: number | null })
+          .rawCategoryScore ?? 0;
+      (ghgCategory as { rawCategoryScore?: number | null }).rawCategoryScore =
+        rawSdg13Score;
       ghgCategory.category_score = {
-        name: mapScore(sdg13Entry.sdg_score),
-        value: sdg13Entry.sdg_score,
+        name: mapScore(floorToHalf(rawSdg13Score)),
+        value: floorToHalf(rawSdg13Score),
       };
 
       if (ghgCategory.category_weight) {
         total_outcome_cat_weight =
           (total_outcome_cat_weight ?? 0) -
           ghgCategory.category_weight * previousGhgScore +
-          ghgCategory.category_weight * sdg13Entry.sdg_score;
+          ghgCategory.category_weight * rawSdg13Score;
       }
     };
 
@@ -1707,7 +1736,9 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
     let aggre_Score = 0;
     let sdg_count_aggre = 0;
     for (let category of sdgArray) {
-      aggre_Score += category.category_score.value;
+      aggre_Score +=
+        (category as { rawCategoryScore?: number | null }).rawCategoryScore ??
+        0;
       sdg_count_aggre++;
     }
 
@@ -1723,13 +1754,13 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
     }
 
     if (sdg_count_aggre != 0) {
-      finalProcessDataArray.aggregatedScore.value = this.round(aggre_Score / 2);
+      const rawAggregatedScore = aggre_Score / sdg_count_aggre;
+      finalProcessDataArray.aggregatedScore.value = floorToHalf(rawAggregatedScore);
       finalProcessDataArray.aggregatedScore.name = this.mapScaleScores(
-        this.round(aggre_Score / sdg_count_aggre),
+        floorToHalf(rawAggregatedScore),
       );
       totalRelevantOutcomeWeight += 50;
-      total_outcome_cat_weight +=
-        50 * finalProcessDataArray.aggregatedScore.value;
+      total_outcome_cat_weight += 50 * rawAggregatedScore;
     } else {
       finalProcessDataArray.aggregatedScore.value = null;
       finalProcessDataArray.aggregatedScore.name = '-';
@@ -1737,7 +1768,7 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
 
     finalProcessDataArray.outcomeData = outcomeArray;
     if (total_outcome_cat_weight != null && totalRelevantOutcomeWeight > 0) {
-      finalProcessDataArray.outcomeScore = this.round(
+      finalProcessDataArray.outcomeScore = floorToHalf(
         total_outcome_cat_weight / totalRelevantOutcomeWeight,
       );
     }
@@ -1789,11 +1820,12 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
         }
         if (notNullCount == 0) {
           score = 'Outside assessment boundaries';
-        } else
-          score = this.round(
-            (scaleSDG.sdg_score + matchingSustainedSDG.sdg_score) /
-              notNullCount,
-          );
+        } else {
+          const rawScaleScore = scaleSDG.rawSdgScore ?? scaleSDG.sdg_score;
+          const rawSustainedScore =
+            matchingSustainedSDG.rawSdgScore ?? matchingSustainedSDG.sdg_score;
+          score = floorToHalf((rawScaleScore + rawSustainedScore) / notNullCount);
+        }
         result.push({
           name: scaleSDG.name,
           score: score,
@@ -2527,8 +2559,8 @@ export class InvestorToolService extends TypeOrmCrudService<InvestorTool> {
       } as any,
     };
   }
-  round(value: number) {
-    return Math.round(value);
+  roundScore(value: number) {
+    return floorToHalf(value);
   }
   mapRelevance(value: number) {
     switch (value) {

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -23,6 +23,8 @@ import { InvestorToolService } from 'src/investor-tool/investor-tool.service';
 import { SdgPriority } from 'src/investor-tool/entities/sdg-priority.entity';
 import { Results } from 'src/methodology-assessment/entities/results.entity';
 import { isNull } from '@nestjsx/util';
+import { averageValidOutcomeScores } from 'src/shared/outcome-ghg-fallback.util';
+import { floorToHalf, floorToHalfOrNull } from 'src/shared/score-rounding.util';
 
 @Injectable()
 export class PortfolioService extends TypeOrmCrudService<Portfolio> {
@@ -779,7 +781,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
               ? (score += int.sustained_score.value)
               : (score = int.sustained_score.value);
           }
-          score !== null ? (score = Math.round(score / 2)) : (score = score);
+          score !== null ? (score = floorToHalf(score / 2)) : (score = score);
           int['category_score'] = this.mapNameAndValue(
             this.investorToolService.mapScaleScores(score),
             score,
@@ -887,7 +889,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
       (int) => {
         let score =
           sc_cat_total[int.assessment_id] !== null
-            ? Math.round(
+            ? floorToHalf(
                 sc_cat_total[int.assessment_id] /
                   (scale_comparison.col_set_2.length - 4),
               )
@@ -904,7 +906,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
       (int) => {
         let score =
           ss_cat_total[int.assessment_id] !== null
-            ? Math.round(
+            ? floorToHalf(
                 ss_cat_total[int.assessment_id] /
                   (sustained_comparison.col_set_2.length - 4),
               )
@@ -928,7 +930,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
             ? (score += int.sustained_score.value)
             : (score = int.sustained_score.value);
         }
-        score !== null ? (score = Math.round(score / 2)) : (score = score);
+        score !== null ? (score = floorToHalf(score / 2)) : (score = score);
         int['category_score'] = this.mapNameAndValue(
           this.investorToolService.mapScaleScores(score),
           score,
@@ -947,7 +949,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
             ? (score += int.sustained_score.value)
             : (score = int.sustained_score.value);
         }
-        score !== null ? (score = Math.round(score / 2)) : (score = score);
+        score !== null ? (score = floorToHalf(score / 2)) : (score = score);
         int['category_score'] = this.mapNameAndValue(
           this.investorToolService.mapScaleScores(score),
           score,
@@ -971,19 +973,19 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
     scaleGhgData.interventions.map((int) => {
       let scale_score =
         scale_cat_total[int.assessment_id] !== null
-          ? Math.round(
+          ? floorToHalf(
               scale_cat_total[int.assessment_id] /
                 scale_cat_count[int.assessment_id],
             )
           : null;
       let sustaine_score =
         sustain_cat_total[int.assessment_id] !== null
-          ? Math.round(
+          ? floorToHalf(
               sustain_cat_total[int.assessment_id] /
                 sustain_cat_count[int.assessment_id],
             )
           : null;
-      let _cat_score = Math.round((scale_score + sustaine_score) / 2);
+      let _cat_score = floorToHalf((scale_score + sustaine_score) / 2);
       outcome_level_comparison.interventions.push({
         id: int.id,
         name: int.name,
@@ -1409,7 +1411,7 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
     sdgs.map((sd) => {
       let code = sd.sdg?.name.replace(' ', '_');
       let sdg_val = sdgs_score['SDG ' + sd.sdg?.number + ' - ' + sd.sdg?.name];
-      let val = sdg_val === null ? null : Math.round(sdg_val / 2);
+      let val = sdg_val === null ? null : floorToHalf(sdg_val / 2);
       let ans = this.mapNameAndValue(
         this.investorToolService.mapScaleScores(val),
         val,
@@ -1564,8 +1566,8 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
       let subnational = data.scale_SDs.find(
         (o) => o.ch_code === 'MICRO_LEVEL' && o.SDG === sd,
       )?.outcome_score;
-      let cat_score = Math.round(
-        (+international + +national + +subnational) / 3,
+      let cat_score = floorToHalfOrNull(
+        averageValidOutcomeScores([international, national, subnational]),
       );
       scale_SDs[sd] = {
         col_set_1: { label: 'Scale - ' + sd, colspan: 4 },
@@ -1663,7 +1665,9 @@ export class PortfolioService extends TypeOrmCrudService<Portfolio> {
       let short_term = data.sustained_SDs.find(
         (o) => o.ch_code === 'SHORT_TERM' && o.SDG === sd,
       )?.outcome_score;
-      let cat_score = Math.round((+long_term + +medium_term + +short_term) / 3);
+      let cat_score = floorToHalfOrNull(
+        averageValidOutcomeScores([long_term, medium_term, short_term]),
+      );
       sustained_SDs[sd] = {
         col_set_1: { label: 'Sustained - ' + sd, colspan: 4 },
         data: {

--- a/src/report/report-html-genarates/report-pages/report-pages.service.ts
+++ b/src/report/report-html-genarates/report-pages/report-pages.service.ts
@@ -21,10 +21,28 @@ import {
   ReportCoverPage,
   ReportTableOfContent,
 } from 'src/report/dto/report.dto';
+import { scoresMatchMatrixCell } from 'src/shared/score-rounding.util';
 
 @Injectable()
 export class ReportPagesService {
   constructor() {}
+
+  private formatCmOutcomeScore(
+    score: string | number | null | undefined,
+  ): string {
+    if (score === null || score === undefined || score === '') {
+      return '-';
+    }
+    return String(score);
+  }
+
+  private formatAggregatedScore(score: number | null | undefined): string {
+    if (score === null || score === undefined) {
+      return 'no data found';
+    }
+    return String(score);
+  }
+
   xData = [
     { label: 'Major', value: 3 },
     { label: 'Moderate', value: 2 },
@@ -2218,7 +2236,7 @@ justification which supports the score and refers to documents which may back th
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
                 <td>${a.starting_situation ? a.starting_situation : '-'}</td>
                 <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
           
                 <td>${
                   a.justification
@@ -2234,7 +2252,7 @@ justification which supports the score and refers to documents which may back th
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
                 <td>${a.starting_situation ? a.starting_situation : '-'}</td>
                 <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                
                 <td>${
                   a.justification
@@ -2278,7 +2296,7 @@ justification which supports the score and refers to documents which may back th
                   sustained_ghg.length
                 }" >Outcome sustained over time - GHGs</td>
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                 <td>${
                   a.outcome_score_explain ? a.outcome_score_explain : '-'
                 }</td>
@@ -2294,7 +2312,7 @@ justification which supports the score and refers to documents which may back th
                } else {
                  return `<tr>
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                 <td>${
                   a.outcome_score_explain ? a.outcome_score_explain : '-'
                 }</td>
@@ -2360,7 +2378,7 @@ justification which supports the score and refers to documents which may back th
               <td>${a.characteristic ? a.characteristic : '-'}</td>
               <td>${a.starting_situation ? a.starting_situation : '-'}</td>
               <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-              <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+              <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
             
               <td>${
                 a.justification
@@ -2376,7 +2394,7 @@ justification which supports the score and refers to documents which may back th
             <td>${a.characteristic ? a.characteristic : '-'}</td>
             <td>${a.starting_situation ? a.starting_situation : '-'}</td>
             <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-            <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+            <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
             
             <td>${
               a.justification
@@ -2420,7 +2438,7 @@ justification which supports the score and refers to documents which may back th
                 sustained_adaptation.length
               }" >Outcome sustained over time - adaptation cobenefits</td>
               <td>${a.characteristic ? a.characteristic : '-'}</td>
-              <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+              <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
               <td>${
                 a.outcome_score_explain ? a.outcome_score_explain : '-'
               }</td>
@@ -2436,7 +2454,7 @@ justification which supports the score and refers to documents which may back th
                 } else {
                   return `<tr>
               <td>${a.characteristic ? a.characteristic : '-'}</td>
-              <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+              <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
               <td>${
                 a.outcome_score_explain ? a.outcome_score_explain : '-'
               }</td>
@@ -2505,7 +2523,7 @@ justification which supports the score and refers to documents which may back th
                   <td>${a.characteristic ? a.characteristic : '-'}</td>
                   <td>${a.starting_situation ? a.starting_situation : '-'}</td>
                   <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-                  <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                  <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                   
                   <td>${
                     a.justification
@@ -2522,7 +2540,7 @@ justification which supports the score and refers to documents which may back th
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
                 <td>${a.starting_situation ? a.starting_situation : '-'}</td>
                 <td>${a.expected_impact ? a.expected_impact : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                 
                 <td>${
                   a.justification
@@ -2588,7 +2606,7 @@ justification which supports the score and refers to documents which may back th
                 }">Outcome sustained over time - sustainable development</td>
                 <td>${a.SDG ? a.SDG : '-'}</td>
                 <td>${a.characteristic ? a.characteristic : '-'}</td>
-                <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+                <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
                 <td>${
                   a.outcome_score_explain ? a.outcome_score_explain : '-'
                 }</td>
@@ -2605,7 +2623,7 @@ justification which supports the score and refers to documents which may back th
                     return `<tr>
               <td>${a.SDG ? a.SDG : '-'}</td>
               <td>${a.characteristic ? a.characteristic : '-'}</td>
-              <td>${a.outcome_score ? a.outcome_score : '-'}</td>
+              <td>${this.formatCmOutcomeScore(a.outcome_score)}</td>
               <td>${
                 a.outcome_score_explain ? a.outcome_score_explain : '-'
               }</td>
@@ -2718,71 +2736,45 @@ justification which supports the score and refers to documents which may back th
        <tbody class="table-body">
        <tr>
          <td >Scale of outcome - GHGs</td>
-         <td >${
-           content.outcomes_categories_assessment.scale_ghg_score != null ||
-           content.outcomes_categories_assessment.scale_ghg_score != undefined
-             ? content.outcomes_categories_assessment.scale_ghg_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.scale_ghg_score,
+         )}</td>
        </tr>
        <tr>
          <td >Scale of outcome - sustainable development </td>
-         <td >${
-           content.outcomes_categories_assessment.scale_sdg_score != null ||
-           content.outcomes_categories_assessment.scale_sdg_score != undefined
-             ? content.outcomes_categories_assessment.scale_sdg_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.scale_sdg_score,
+         )}</td>
        </tr>
        <tr>
          <td >Scale of outcome - adaptation co-benefits </td>
-         <td >${
-           content.outcomes_categories_assessment.scale_adaptation_score !=
-             null ||
-           content.outcomes_categories_assessment.scale_adaptation_score !=
-             undefined
-             ? content.outcomes_categories_assessment.scale_adaptation_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.scale_adaptation_score,
+         )}</td>
        </tr>
        <tr>
          <td >Outcome sustained over time - GHGs </td>
-         <td >${
-           content.outcomes_categories_assessment.sustained_ghg_score != null ||
-           content.outcomes_categories_assessment.sustained_ghg_score !=
-             undefined
-             ? content.outcomes_categories_assessment.sustained_ghg_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.sustained_ghg_score,
+         )}</td>
        </tr>
        <tr>
          <td >Outcome sustained over time - sustainable development</td>
-         <td >${
-           content.outcomes_categories_assessment.sustained_sdg_score != null ||
-           content.outcomes_categories_assessment.sustained_sdg_score !=
-             undefined
-             ? content.outcomes_categories_assessment.sustained_sdg_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.sustained_sdg_score,
+         )}</td>
        </tr>
        <tr>
          <td >Outcome sustained over time - adaptation co-benefits </td>
-         <td >${
-           content.outcomes_categories_assessment.sustained_adaptation_score !=
-             null ||
-           content.outcomes_categories_assessment.sustained_adaptation_score !=
-             undefined
-             ? content.outcomes_categories_assessment.sustained_adaptation_score
-             : 'no data found'
-         }</td>
+         <td >${this.formatAggregatedScore(
+           content.outcomes_categories_assessment.sustained_adaptation_score,
+         )}</td>
        </tr>
        <tr>
          <td class="bold-table-row"> Outcomes score </td>
-         <td class="bold-table-row">${
-           content.outcomeScore != null || content.outcomeScore != undefined
-             ? content.outcomeScore
-             : 'no data found'
-         }</td>
+         <td class="bold-table-row">${this.formatAggregatedScore(
+           content.outcomeScore,
+         )}</td>
        </tr>
       
   
@@ -4835,7 +4827,16 @@ dimensions: Outcome (extent and sustained nature of transformation) and Process 
     y: number,
     contentTwo: ReportContentTwo | ReportCarbonMarketDtoContentFour,
   ) {
-    return contentTwo.processScore === y && contentTwo.outcomeScore === x;
+    if (contentTwo.processScore == null || contentTwo.outcomeScore == null) {
+      return false;
+    }
+
+    return scoresMatchMatrixCell(
+      contentTwo.processScore,
+      contentTwo.outcomeScore,
+      y,
+      x,
+    );
   }
   generateHeatMapforComparison(
     y: number,
@@ -4873,8 +4874,8 @@ dimensions: Outcome (extent and sustained nature of transformation) and Process 
     y: number,
     contentTwo: ComparisonReportReportContentFive,
   ) {
-    let a = contentTwo.scores?.filter(
-      (item) => item.processScore === y && item.outcomeScore === x,
+    let a = contentTwo.scores?.filter((item) =>
+      scoresMatchMatrixCell(item.processScore, item.outcomeScore, y, x),
     ).length;
 
     return a;

--- a/src/shared/outcome-ghg-fallback.util.spec.ts
+++ b/src/shared/outcome-ghg-fallback.util.spec.ts
@@ -20,6 +20,7 @@ describe('outcome-ghg-fallback.util', () => {
   describe('averageValidOutcomeScores', () => {
     it('averages valid scores and ignores outside-boundary values', () => {
       expect(averageValidOutcomeScores([3, 3, -99, null])).toBe(3);
+      expect(averageValidOutcomeScores([2, 3, -99, null])).toBe(2.5);
       expect(averageValidOutcomeScores([-99, null])).toBeNull();
     });
   });

--- a/src/shared/outcome-ghg-fallback.util.ts
+++ b/src/shared/outcome-ghg-fallback.util.ts
@@ -21,7 +21,7 @@ export function averageValidOutcomeScores(
     return null;
   }
 
-  return Math.round(valid.reduce((sum, score) => sum + score, 0) / valid.length);
+  return valid.reduce((sum, score) => sum + score, 0) / valid.length;
 }
 
 export function shouldFallbackGhgCategoryToSdg13(

--- a/src/shared/score-rounding.util.spec.ts
+++ b/src/shared/score-rounding.util.spec.ts
@@ -1,0 +1,41 @@
+import {
+  floorToHalf,
+  floorToHalfOrNull,
+  floorToWholeForMatrix,
+  scoresMatchMatrixCell,
+} from './score-rounding.util';
+
+describe('score-rounding.util', () => {
+  describe('floorToHalf', () => {
+    it('floors to the nearest half-integer', () => {
+      expect(floorToHalf(2.9)).toBe(2.5);
+      expect(floorToHalf(2.5)).toBe(2.5);
+      expect(floorToHalf(2.3)).toBe(2);
+      expect(floorToHalf(-1.3)).toBe(-1.5);
+      expect(floorToHalf(-1.1)).toBe(-1.5);
+    });
+  });
+
+  describe('floorToHalfOrNull', () => {
+    it('returns null for nullish values', () => {
+      expect(floorToHalfOrNull(null)).toBeNull();
+      expect(floorToHalfOrNull(undefined)).toBeNull();
+    });
+  });
+
+  describe('floorToWholeForMatrix', () => {
+    it('floors display scores for matrix placement', () => {
+      expect(floorToWholeForMatrix(2.9)).toBe(2);
+      expect(floorToWholeForMatrix(2.5)).toBe(2);
+      expect(floorToWholeForMatrix(-0.5)).toBe(-1);
+    });
+  });
+
+  describe('scoresMatchMatrixCell', () => {
+    it('matches matrix cells using floored coordinates', () => {
+      expect(scoresMatchMatrixCell(2.9, 1.5, 2, 1)).toBe(true);
+      expect(scoresMatchMatrixCell(2.5, 2.5, 2, 2)).toBe(true);
+      expect(scoresMatchMatrixCell(2.5, 2.5, 3, 2)).toBe(false);
+    });
+  });
+});

--- a/src/shared/score-rounding.util.ts
+++ b/src/shared/score-rounding.util.ts
@@ -1,0 +1,35 @@
+/**
+ * Rounds a score down to the nearest half-integer (0, 0.5, 1, 1.5, …).
+ */
+export function floorToHalf(value: number): number {
+  return Math.floor(value * 2) / 2;
+}
+
+export function floorToHalfOrNull(
+  value: number | null | undefined,
+): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  return floorToHalf(value);
+}
+
+/**
+ * Maps a display score to the whole-integer matrix grid coordinate (always rounds down).
+ */
+export function floorToWholeForMatrix(value: number): number {
+  return Math.floor(value);
+}
+
+export function scoresMatchMatrixCell(
+  processScore: number,
+  outcomeScore: number,
+  matrixProcessY: number,
+  matrixOutcomeX: number,
+): boolean {
+  return (
+    floorToWholeForMatrix(processScore) === matrixProcessY &&
+    floorToWholeForMatrix(outcomeScore) === matrixOutcomeX
+  );
+}


### PR DESCRIPTION
SD category scores for International / National / Subnational levels now use the same valid-score averaging as the assessment engine (averageValidOutcomeScores), excluding “outside assessment boundaries” (-99) instead of always dividing by three.

Replaced DOM-based export (which misaligned summary scores due to rowspan and extra download columns) with a programmatic export built from calculated scores, including a dedicated aggregate outcome summary table.

Introduced a shared floorToHalf utility that rounds scores down to the nearest 0.5 (0, 0.5, 1, 1.5, …). Calculations keep full precision until the final step; only displayed and stored scores are rounded.